### PR TITLE
アラートが存在したら追加処理をしないようにする(予約枠作成)

### DIFF
--- a/app/controllers/reservation_frames_controller.rb
+++ b/app/controllers/reservation_frames_controller.rb
@@ -23,6 +23,8 @@ class ReservationFramesController < ApplicationController
       flash[:alert] = '予約日時が範囲外です' if @start_at < st || @start_at > en
     end
 
+    redirect_to request.referer and return if flash[:alert]
+    
     reservation_frame = current_user.reservation_frames.build(
       reserved_at: @start_at,
       status: args[:status],

--- a/app/controllers/reservation_frames_controller.rb
+++ b/app/controllers/reservation_frames_controller.rb
@@ -23,7 +23,7 @@ class ReservationFramesController < ApplicationController
       flash[:alert] = '予約日時が範囲外です' if @start_at < st || @start_at > en
     end
 
-    redirect_to request.referer and return if flash[:alert]
+    return redirect_to request.referer if flash[:alert]
     
     reservation_frame = current_user.reservation_frames.build(
       reserved_at: @start_at,


### PR DESCRIPTION
## 概要

土曜日の時間外に予約枠を作成するとエラーメッセージは出るが, 予約枠が作成されてしまう

土曜日の予約可能時間帯: 11:00~15:00

### 例
予約した日: 2021年9月8日水曜日
予約枠作成日: 2021年9月18日土曜日 10:00~10:30

予約枠作成 -> エラーメッセージが出る("予約日時が時間外です") が,
予約枠は作成されている